### PR TITLE
Call Nodes

### DIFF
--- a/src/main/scala/io/joern/javascr2cpg/passes/AstCreationPass.scala
+++ b/src/main/scala/io/joern/javascr2cpg/passes/AstCreationPass.scala
@@ -272,7 +272,12 @@ class AstCreator(filename: String) {
       // TODO: Generate AST children here
       case Failure(_) =>
     }
-    // TODO: Line numbers
+    if (call.getName.getBegin.isPresent) {
+      val begin = call.getName.getBegin
+      callNode
+        .lineNumber(Option(begin.get().line))
+        .columnNumber(Option(begin.get().column))
+    }
     diffGraph.addNode(callNode)
     callNode
   }

--- a/src/test/scala/io/joern/javasrc2cpg/querying/CallTests.scala
+++ b/src/test/scala/io/joern/javasrc2cpg/querying/CallTests.scala
@@ -31,7 +31,7 @@ class CallTests extends JavaSrcCodeToCpgFixture {
     x.methodFullName shouldBe "Foo.add:int(int,int)"
     x.signature shouldBe "int(int,int)"
     x.argumentIndex shouldBe 2
-//    x.lineNumber shouldBe Some(8)
+    x.lineNumber shouldBe Some(8)
   }
 
 //  "should allow traversing from call to arguments" in {


### PR DESCRIPTION
Here is the PR to just add call nodes, I left TODOs on where things still need to be done:
* Return node: In the case an expression is after a return node I just made boilerplate for the return method and made a call to parse expressions
* Call node arguments: For the sake that this will be versions of other nodes, e.g. literals, variables, etc. I have not handled this yet
* Attaching call node to AST parent: Not sure what we're going to do with resolving which block will be the parent block yet so I've left that out for now