### PR TITLE
Pass two more call-related tests

### DIFF
--- a/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
+++ b/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
@@ -4,6 +4,7 @@ import io.joern.javasrc2cpg.passes.AstCreationPass
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.passes.IntervalKeyPool
 import io.shiftleft.semanticcpg.passes.FileCreationPass
+import io.shiftleft.semanticcpg.passes.containsedges.ContainsEdgePass
 import io.shiftleft.semanticcpg.passes.metadata.MetaDataPass
 import io.shiftleft.semanticcpg.passes.namespacecreator.NamespaceCreator
 import io.shiftleft.semanticcpg.passes.typenodes.{TypeDeclStubCreator, TypeNodePass}
@@ -47,6 +48,8 @@ class JavaSrc2Cpg {
     new TypeNodePass(astCreator.global.usedTypes.keys().asScala.toList, cpg, Some(typesKeyPool))
       .createAndApply()
     new TypeDeclStubCreator(cpg).createAndApply()
+
+    new ContainsEdgePass(cpg).createAndApply()
     cpg
   }
 

--- a/src/test/scala/io/joern/javasrc2cpg/querying/CallTests.scala
+++ b/src/test/scala/io/joern/javasrc2cpg/querying/CallTests.scala
@@ -34,35 +34,35 @@ class CallTests extends JavaSrcCodeToCpgFixture {
     x.lineNumber shouldBe Some(8)
   }
 
-//  "should allow traversing from call to arguments" in {
-//    cpg.call("add").argument.size shouldBe 3
-//    val List(arg0) = cpg.call("add").argument(0).l
-//    arg0.isInstanceOf[nodes.Identifier] shouldBe true
-//    arg0.asInstanceOf[nodes.Identifier].name shouldBe "this"
-//    arg0.code shouldBe "this"
-//    arg0.order shouldBe 0
-//    arg0.argumentIndex shouldBe 0
-//
-//    val List(arg1) = cpg.call("add").argument(1).l
-//    arg1.isInstanceOf[nodes.Identifier] shouldBe true
-//    arg1.asInstanceOf[nodes.Identifier].name shouldBe "argc"
-//    arg1.code shouldBe "argc"
-//    arg1.order shouldBe 1
-//    arg1.argumentIndex shouldBe 1
-//
-//    val List(arg2) = cpg.call("add").argument(2).l
-//    arg2.asInstanceOf[nodes.Literal].code shouldBe "3"
-//    arg2.isInstanceOf[nodes.Literal] shouldBe true
-//    arg2.code shouldBe "3"
-//    arg2.order shouldBe 2
-//    arg2.argumentIndex shouldBe 2
-//  }
+  "should allow traversing from call to arguments" in {
+    cpg.call("add").argument.size shouldBe 3
+    val List(arg0) = cpg.call("add").argument(0).l
+    arg0.isInstanceOf[nodes.Identifier] shouldBe true
+    arg0.asInstanceOf[nodes.Identifier].name shouldBe "this"
+    arg0.code shouldBe "this"
+    arg0.order shouldBe 0
+    arg0.argumentIndex shouldBe 0
 
-//  "should allow traversing from call to surrounding method" in {
-//    val List(x) = cpg.call("add").method.l
-//    x.name shouldBe "main"
-//  }
-//
+    val List(arg1) = cpg.call("add").argument(1).l
+    arg1.isInstanceOf[nodes.Identifier] shouldBe true
+    arg1.asInstanceOf[nodes.Identifier].name shouldBe "argc"
+    arg1.code shouldBe "argc"
+    arg1.order shouldBe 1
+    arg1.argumentIndex shouldBe 1
+
+    val List(arg2) = cpg.call("add").argument(2).l
+    arg2.asInstanceOf[nodes.Literal].code shouldBe "3"
+    arg2.isInstanceOf[nodes.Literal] shouldBe true
+    arg2.code shouldBe "3"
+    arg2.order shouldBe 2
+    arg2.argumentIndex shouldBe 2
+  }
+
+  "should allow traversing from call to surrounding method" in {
+    val List(x) = cpg.call("add").method.l
+    x.name shouldBe "main"
+  }
+
 //  "should allow traversing from call to callee method" in {
 //    val List(x) = cpg.call("add").callee.l
 //    x.name shouldBe "add"


### PR DESCRIPTION
* argument nodes of calls are now created correctly, including the `this` argument for resolved calls
* traversing from call to surrounding method via contains edges works now