### PR TITLE
jcoetzee/boolean array

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ organization := "io.joern"
 
 scalaVersion := "2.13.6"
 
-val cpgVersion       = "1.3.314"
+val cpgVersion       = "1.3.322"
 val scalatestVersion = "3.1.1"
 
 Test / fork := true

--- a/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -574,7 +574,6 @@ class AstCreator(filename: String, global: Global) {
     callAst(callNode, args)
   }
 
-
   def astForBinaryExpr(stmt: BinaryExpr, order: Int): Ast = {
     val operatorName = stmt.getOperator match {
       case BinaryExpr.Operator.OR                   => Operators.logicalOr

--- a/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -313,9 +313,9 @@ class AstCreator(filename: String, global: Global) {
       case x: ContinueStmt                      => Seq(astForContinueStatement(x, order))
       case x: DoStmt                            => Seq(astForDo(x, order))
       case x: EmptyStmt                         => Seq()
-      case x: ExplicitConstructorInvocationStmt => Seq()                                // TODO: translate to Call
+      case x: ExplicitConstructorInvocationStmt => Seq() // TODO: translate to Call
       case x: ExpressionStmt                    => astsForExpression(x.getExpression, order)
-      case x: ForEachStmt                       => Seq()                                // TODO: translate to For
+      case x: ForEachStmt                       => Seq() // TODO: translate to For
       case x: ForStmt                           => Seq(astForFor(x, order))
       case x: IfStmt                            => Seq(astForIf(x, order))
       case x: LabeledStmt                       => astsForLabeledStatement(x, order)

--- a/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -11,6 +11,7 @@ import com.github.javaparser.ast.expr.{
   AnnotationExpr,
   ArrayAccessExpr,
   ArrayInitializerExpr,
+  ArrayCreationExpr,
   AssignExpr,
   BinaryExpr,
   CastExpr,
@@ -306,15 +307,15 @@ class AstCreator(filename: String, global: Global) {
 
   private def astsForStatement(statement: Statement, order: Int): Seq[Ast] = {
     statement match {
-      case x: AssertStmt                        => Seq() // TODO: translate to Call
+      case x: AssertStmt                        => Seq(astForAssertStatement(x, order)) // TODO: translate to Call
       case x: BlockStmt                         => Seq(astForBlockStatement(x, order))
       case x: BreakStmt                         => Seq(astForBreakStatement(x, order))
       case x: ContinueStmt                      => Seq(astForContinueStatement(x, order))
       case x: DoStmt                            => Seq(astForDo(x, order))
       case x: EmptyStmt                         => Seq()
-      case x: ExplicitConstructorInvocationStmt => Seq() // TODO: translate to Call
+      case x: ExplicitConstructorInvocationStmt => Seq()                                // TODO: translate to Call
       case x: ExpressionStmt                    => astsForExpression(x.getExpression, order)
-      case x: ForEachStmt                       => Seq() // TODO: translate to For
+      case x: ForEachStmt                       => Seq()                                // TODO: translate to For
       case x: ForStmt                           => Seq(astForFor(x, order))
       case x: IfStmt                            => Seq(astForIf(x, order))
       case x: LabeledStmt                       => astsForLabeledStatement(x, order)
@@ -454,6 +455,20 @@ class AstCreator(filename: String, global: Global) {
     labelNodes.map(x => Ast(x)) ++ statementAsts
   }
 
+  private def astForAssertStatement(stmt: AssertStmt, order: Int): Ast = {
+    // TODO: Is this sufficient for the AST?
+    val callNode = NewCall()
+      .name("assert")
+      .methodFullName("assert")
+      .dispatchType(DispatchTypes.STATIC_DISPATCH)
+      .code(stmt.toString)
+      .argumentIndex(order)
+      .order(order)
+
+    val args = astsForExpression(stmt.getCheck, 1)
+    callAst(callNode, args)
+  }
+
   private def astForBlockStatement(stmt: BlockStmt, order: Int): Ast = {
     val block = NewBlock(order = order, lineNumber = line(stmt), columnNumber = column(stmt))
     Ast(block).withChildren(
@@ -473,6 +488,90 @@ class AstCreator(filename: String, global: Global) {
     } else {
       Seq()
     }
+  }
+
+  def astForUnaryExpr(stmt: UnaryExpr, order: Int): Ast = {
+    val operatorName = stmt.getOperator match {
+      case UnaryExpr.Operator.LOGICAL_COMPLEMENT => Operators.logicalNot
+      case UnaryExpr.Operator.POSTFIX_DECREMENT  => Operators.postDecrement
+      case UnaryExpr.Operator.POSTFIX_INCREMENT  => Operators.postIncrement
+      case UnaryExpr.Operator.PREFIX_DECREMENT   => Operators.preDecrement
+      case UnaryExpr.Operator.PREFIX_INCREMENT   => Operators.preIncrement
+      case UnaryExpr.Operator.BITWISE_COMPLEMENT => Operators.not
+      case UnaryExpr.Operator.PLUS               => Operators.plus
+      case UnaryExpr.Operator.MINUS              => Operators.minus
+    }
+
+    val callNode = NewCall()
+      .name(operatorName)
+      .methodFullName(operatorName)
+      .dispatchType(DispatchTypes.STATIC_DISPATCH)
+      .code(stmt.toString)
+      .argumentIndex(order)
+      .order(order)
+
+    val args = astsForExpression(stmt.getExpression, 1)
+    callAst(callNode, args)
+  }
+
+  def astForArrayAccessExpr(expr: ArrayAccessExpr, order: Int): Ast = {
+    val callNode = NewCall()
+      .name(Operators.indexAccess)
+      .dispatchType(DispatchTypes.STATIC_DISPATCH)
+      .code(expr.toString)
+      .order(order)
+      .argumentIndex(order)
+      .methodFullName(Operators.indexAccess)
+      .lineNumber(line(expr))
+      .columnNumber(column(expr))
+      .build
+
+    val args = astsForExpression(expr.getIndex, 1)
+    callAst(callNode, args)
+  }
+
+  def astForArrayCreationExpr(expr: ArrayCreationExpr, order: Int): Ast = {
+    // TODO: Decide how to deal with this properly
+    val name = "arrayCreation"
+    val callNode = NewCall()
+      .name(name)
+      .dispatchType(DispatchTypes.STATIC_DISPATCH)
+      .code(expr.toString)
+      .order(order)
+      .argumentIndex(order)
+      .methodFullName(name)
+      .lineNumber(line(expr))
+      .columnNumber(column(expr))
+      .build
+
+    val levelAsts = expr.getLevels.asScala.zipWithIndex.flatMap { case (lvl, idx) =>
+      lvl.getDimension.asScala match {
+        case Some(dimension) => astsForExpression(dimension, idx + 1)
+
+        case None => Seq.empty
+      }
+    }
+
+    val initializerAst =
+      expr.getInitializer.asScala.map(astForArrayInitializerExpr(_, expr.getLevels.size() + 1))
+
+    callAst(callNode, (levelAsts ++ initializerAst).toSeq)
+  }
+
+  def astForArrayInitializerExpr(expr: ArrayInitializerExpr, order: Int): Ast = {
+    val callNode = NewCall()
+      .name("arrayInitializer")
+      .dispatchType(DispatchTypes.STATIC_DISPATCH)
+      .code(expr.toString)
+      .order(order)
+      .argumentIndex(order)
+      .methodFullName("arrayInitializer")
+      .lineNumber(line(expr))
+      .columnNumber(column(expr))
+      .build
+
+    val args = expr.getValues.asScala.flatMap(node => astsForExpression(node, 1)).toSeq
+    callAst(callNode, args)
   }
 
   def astForBinaryExpr(stmt: BinaryExpr, order: Int): Ast = {
@@ -507,7 +606,7 @@ class AstCreator(filename: String, global: Global) {
       .argumentIndex(order)
       .order(order)
 
-    val args = astsForExpression(stmt.getLeft, 0) ++ astsForExpression(stmt.getRight, 1)
+    val args = astsForExpression(stmt.getLeft, 1) ++ astsForExpression(stmt.getRight, 2)
     callAst(callNode, args)
   }
 
@@ -518,8 +617,15 @@ class AstCreator(filename: String, global: Global) {
       val typeFullName = registerType(v.getType.resolve().describe())
 
       val initializerAst = v.getInitializer.asScala.zipWithIndex.map { case (initializer, i) =>
-        val code                    = s"$name = ${initializer.toString}"
-        val initializerTypeFullName = registerType(initializer.calculateResolvedType().describe())
+        val code = s"$name = ${initializer.toString}"
+        val initializerTypeFullName =
+          try {
+            registerType(initializer.calculateResolvedType().describe())
+          } catch {
+            case _: Throwable =>
+              registerType(v.getType.resolve().describe())
+          }
+
         val identifier = NewIdentifier()
           .name(name)
           .order(1)
@@ -562,6 +668,10 @@ class AstCreator(filename: String, global: Global) {
     Ast(NewLiteral().order(order).argumentIndex(order).code(x.toString).typeFullName("double"))
   }
 
+  def astForEnclosedExpression(expr: EnclosedExpr, order: Int): Seq[Ast] = {
+    astsForExpression(expr.getInner, order)
+  }
+
   def astForNameExpr(x: NameExpr, order: Int): Ast = {
     val name         = x.getName.toString
     val typeFullName = registerType(x.resolve().getType.describe())
@@ -578,15 +688,16 @@ class AstCreator(filename: String, global: Global) {
   private def astsForExpression(expression: Expression, order: Int): Seq[Ast] = {
     expression match {
       case x: AnnotationExpr          => Seq()
-      case x: ArrayAccessExpr         => Seq()
-      case x: ArrayInitializerExpr    => Seq()
+      case x: ArrayAccessExpr         => Seq(astForArrayAccessExpr(x, order))
+      case x: ArrayCreationExpr       => Seq(astForArrayCreationExpr(x, order))
+      case x: ArrayInitializerExpr    => Seq(astForArrayInitializerExpr(x, order))
       case x: AssignExpr              => Seq()
       case x: BinaryExpr              => Seq(astForBinaryExpr(x, order))
       case x: CastExpr                => Seq()
       case x: ClassExpr               => Seq()
       case x: ConditionalExpr         => Seq()
       case x: DoubleLiteralExpr       => Seq(astForDoubleLiteral(x, order))
-      case x: EnclosedExpr            => Seq()
+      case x: EnclosedExpr            => astForEnclosedExpression(x, order)
       case x: FieldAccessExpr         => Seq()
       case x: IntegerLiteralExpr      => Seq(astForIntegerLiteral(x, order))
       case x: InstanceOfExpr          => Seq()
@@ -601,9 +712,8 @@ class AstCreator(filename: String, global: Global) {
       case x: SwitchExpr              => Seq()
       case x: ThisExpr                => Seq()
       case x: TypeExpr                => Seq()
-      case x: UnaryExpr               => Seq()
+      case x: UnaryExpr               => Seq(astForUnaryExpr(x, order))
       case x: VariableDeclarationExpr => astForVariableDecl(x, order)
-      case _                          => Seq()
     }
   }
 

--- a/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -307,7 +307,7 @@ class AstCreator(filename: String, global: Global) {
 
   private def astsForStatement(statement: Statement, order: Int): Seq[Ast] = {
     statement match {
-      case x: AssertStmt                        => Seq(astForAssertStatement(x, order)) // TODO: translate to Call
+      case x: AssertStmt                        => Seq(astForAssertStatement(x, order))
       case x: BlockStmt                         => Seq(astForBlockStatement(x, order))
       case x: BreakStmt                         => Seq(astForBreakStatement(x, order))
       case x: ContinueStmt                      => Seq(astForContinueStatement(x, order))
@@ -456,7 +456,6 @@ class AstCreator(filename: String, global: Global) {
   }
 
   private def astForAssertStatement(stmt: AssertStmt, order: Int): Ast = {
-    // TODO: Is this sufficient for the AST?
     val callNode = NewCall()
       .name("assert")
       .methodFullName("assert")
@@ -531,7 +530,6 @@ class AstCreator(filename: String, global: Global) {
   }
 
   def astForArrayCreationExpr(expr: ArrayCreationExpr, order: Int): Ast = {
-    // TODO: Decide how to deal with this properly
     val name = "<operator>.arrayCreator"
     val callNode = NewCall()
       .name(name)

--- a/src/test/scala/io/joern/javasrc2cpg/querying/ArrayTests.scala
+++ b/src/test/scala/io/joern/javasrc2cpg/querying/ArrayTests.scala
@@ -1,0 +1,62 @@
+package io.joern.javasrc2cpg.querying
+
+import io.joern.javasrc2cpg.testfixtures.JavaSrcCodeToCpgFixture
+import io.shiftleft.codepropertygraph.generated.Operators
+import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier, Literal}
+import io.shiftleft.semanticcpg.language.{ICallResolver, NoResolve}
+import io.shiftleft.semanticcpg.language._
+
+class ArrayTests extends JavaSrcCodeToCpgFixture {
+
+  implicit val resolver: ICallResolver = NoResolve
+
+  override val code: String =
+    """
+      |class Foo {
+      |  public void foo() {
+      |    int[] x = {0, 1, 2};
+      |  }
+      |
+      |  public void bar() {
+      |    int[][] x = new int[5][2];
+      |  }
+      |}
+      |""".stripMargin
+
+  "should initialize array with constant initialization expression" in {
+    def m = cpg.method(".*foo.*")
+    val List(assignment) = m.assignments.l
+
+    val arg1 = assignment.argument(1)
+    val arg2 = assignment.argument(2)
+
+    arg1 shouldBe a[Identifier]
+    arg1.asInstanceOf[Identifier].code shouldBe "x"
+    arg1.asInstanceOf[Identifier].typeFullName shouldBe "int[]"
+
+    arg2 shouldBe a[Call]
+    arg2.code shouldBe "{ 0, 1, 2 }"
+    arg2.astChildren.zipWithIndex.foreach { case (arg, idx) =>
+      arg shouldBe a[Literal]
+      arg.code shouldBe idx.toString
+    }
+  }
+
+  "should initialize an array with empty initialization expression" in {
+    def m = cpg.method(".*bar.*")
+    val List(assignment) = m.assignments.l
+
+    val arg1 = assignment.argument(1)
+    val arg2 = assignment.argument(2)
+
+    arg1 shouldBe a[Identifier]
+    arg1.asInstanceOf[Identifier].typeFullName shouldBe "int[][]"
+
+    arg2 shouldBe a[Call]
+    arg2.code shouldBe "new int[5][2]"
+    val lvl1 = arg2.asInstanceOf[Call].argument(1)
+    val lvl2 = arg2.asInstanceOf[Call].argument(2)
+    lvl1.code shouldBe "5"
+    lvl2.code shouldBe "2"
+  }
+}

--- a/src/test/scala/io/joern/javasrc2cpg/querying/BooleanOperationsTests.scala
+++ b/src/test/scala/io/joern/javasrc2cpg/querying/BooleanOperationsTests.scala
@@ -1,0 +1,112 @@
+package io.joern.javasrc2cpg.querying
+
+import io.joern.javasrc2cpg.testfixtures.JavaSrcCodeToCpgFixture
+import io.shiftleft.codepropertygraph.generated.Operators
+import io.shiftleft.codepropertygraph.generated.nodes.{Identifier, Literal}
+import io.shiftleft.semanticcpg.language._
+
+class BooleanOperationsTests extends JavaSrcCodeToCpgFixture {
+
+  implicit val resolver: ICallResolver = NoResolve
+
+  override val code: String =
+    """
+      | public class Foo {
+      |   public static void main(String[] args) {
+      |     boolean a = 1 == 2;
+      |     boolean b = 3 != 4;
+      |     boolean c = 5 > 6;
+      |     boolean d = 7 < 8;
+      |     boolean e = 9 >= 10;
+      |     boolean f = 11 <= 12;
+      |     boolean g = a && b;
+      |     boolean h = c || d;
+      |     boolean i = !h;
+      |     boolean j = a && (b || c);
+      |   }
+      | }
+      |""".stripMargin
+
+  val vars = Seq(
+    ("a", "boolean"),
+    ("b", "boolean"),
+    ("c", "boolean"),
+    ("d", "boolean"),
+    ("e", "boolean"),
+    ("f", "boolean"),
+    ("g", "boolean"),
+    ("h", "boolean"),
+    ("i", "boolean"),
+    ("j", "boolean"),
+  )
+
+  "should contain call nodes with <operation>.assignment for all variables" in {
+    val assignments = cpg.assignment.map(x => (x.target.code, x.typeFullName)).l
+    assignments.size shouldBe 10
+    vars.foreach(x => {
+      assignments contains x shouldBe true
+    })
+  }
+
+  "should contain a call node for the equals operator" in {
+    val List(op)                     = cpg.call.nameExact(Operators.equals).l
+    val List(a: Literal, b: Literal) = op.astOut.l
+    a.code shouldBe "1"
+    b.code shouldBe "2"
+  }
+
+  "should contain a call node for the notEquals operator" in {
+    val List(op)                     = cpg.call.nameExact(Operators.notEquals).l
+    val List(a: Literal, b: Literal) = op.astOut.l
+    a.code shouldBe "3"
+    b.code shouldBe "4"
+  }
+
+  "should contain a call node for the greaterThan operator" in {
+    val List(op)                     = cpg.call.nameExact(Operators.greaterThan).l
+    val List(a: Literal, b: Literal) = op.astOut.l
+    a.code shouldBe "5"
+    b.code shouldBe "6"
+  }
+
+  "should contain a call node for the lessThan operator" in {
+    val List(op)                     = cpg.call.nameExact(Operators.lessThan).l
+    val List(a: Literal, b: Literal) = op.astOut.l
+    a.code shouldBe "7"
+    b.code shouldBe "8"
+  }
+
+  "should contain a call node for the greaterEqualsThan operator" in {
+    val List(op)                     = cpg.call.nameExact(Operators.greaterEqualsThan).l
+    val List(a: Literal, b: Literal) = op.astOut.l
+    a.code shouldBe "9"
+    b.code shouldBe "10"
+  }
+
+  "should contain a call node for the lessEqualsThan operator" in {
+    val List(op)                     = cpg.call.nameExact(Operators.lessEqualsThan).l
+    val List(a: Literal, b: Literal) = op.astOut.l
+    a.code shouldBe "11"
+    b.code shouldBe "12"
+  }
+
+  "should contain a call node for the logicalAnd operator" in {
+    val op                                 = cpg.call.nameExact(Operators.logicalAnd).head
+    val List(a: Identifier, b: Identifier) = op.astOut.l
+    a.name shouldBe "a"
+    b.name shouldBe "b"
+  }
+
+  "should contain a call node for the logicalOr operator" in {
+    val op                                 = cpg.call.nameExact(Operators.logicalOr).head
+    val List(a: Identifier, b: Identifier) = op.astOut.l
+    a.name shouldBe "c"
+    b.name shouldBe "d"
+  }
+
+  "should contain a call node for the logicalNot operator" in {
+    val List(op)            = cpg.call.nameExact(Operators.logicalNot).l
+    val List(a: Identifier) = op.astOut.l
+    a.name shouldBe "h"
+  }
+}

--- a/src/test/scala/io/joern/javasrc2cpg/querying/ControlStructureTests.scala
+++ b/src/test/scala/io/joern/javasrc2cpg/querying/ControlStructureTests.scala
@@ -10,6 +10,13 @@ class ControlStructureTests extends JavaSrcCodeToCpgFixture {
     """
       |class Foo {
       |
+      |int bar(boolean x, boolean y, boolean z) {
+      |  if (x || (y && z)) {
+      |    return 1;
+      |  }
+      |  return 2;
+      |}
+      |
       |void foo(int x, int y) {
       | try {
       | } catch(exc_t exc) {
@@ -71,6 +78,10 @@ class ControlStructureTests extends JavaSrcCodeToCpgFixture {
 
   "should identify `continue`" in {
     cpg.method.name("foo").continue.code.l shouldBe List("continue;")
+  }
+
+  "should handle complex boolean conditions" in {
+    cpg.method.name("bar").ifBlock.condition.code.l shouldBe List("x || (y && z)")
   }
 
 }


### PR DESCRIPTION
# Notes
This PR adds support for a few Java language features:
* Unary operators
* Assert calls
* Array creation, initialization and access
* Enclosed statements
* Assignments
* Unit tests for boolean operations
# Testing
`sbt clean test`

# Example ASTs:
## `int[] x = {1, 2}`
![image](https://user-images.githubusercontent.com/25384566/133281160-ac9babb4-0966-42c4-b5a6-f0e078756b16.png)

## `int[][] y = new int[2][5]`
![image](https://user-images.githubusercontent.com/25384566/133281410-715f5ac5-2053-4346-93de-90f560300c8e.png)

## `x[0] = 5`
![image](https://user-images.githubusercontent.com/25384566/133281646-bd93882f-c5fe-445f-a95a-3fc0051e13c7.png)

## `x[1] = y[0][0] + 2`
![image](https://user-images.githubusercontent.com/25384566/133281780-9fc42c9f-06ac-4bea-a02d-ea62881b93b9.png)
