### PR TITLE
Johannes/basic support 2

### DIFF
--- a/src/test/scala/io/joern/javasrc2cpg/querying/BooleanOperationsTests.scala
+++ b/src/test/scala/io/joern/javasrc2cpg/querying/BooleanOperationsTests.scala
@@ -23,6 +23,7 @@ class BooleanOperationsTests extends JavaSrcCodeToCpgFixture {
       |     boolean h = c || d;
       |     boolean i = !h;
       |     boolean j = a && (b || c);
+      |     boolean k = true;
       |   }
       | }
       |""".stripMargin
@@ -38,11 +39,12 @@ class BooleanOperationsTests extends JavaSrcCodeToCpgFixture {
     ("h", "boolean"),
     ("i", "boolean"),
     ("j", "boolean"),
+    ("k", "boolean")
   )
 
   "should contain call nodes with <operation>.assignment for all variables" in {
     val assignments = cpg.assignment.map(x => (x.target.code, x.typeFullName)).l
-    assignments.size shouldBe 10
+    assignments.size shouldBe vars.size
     vars.foreach(x => {
       assignments contains x shouldBe true
     })

--- a/src/test/scala/io/joern/javasrc2cpg/querying/CfgTests.scala
+++ b/src/test/scala/io/joern/javasrc2cpg/querying/CfgTests.scala
@@ -39,7 +39,7 @@ class CfgTests extends JavaSrcCodeToCpgFixture {
   }
 
   "should find that println post dominates correct nodes" in {
-    cpg.call("println").postDominates.size shouldBe 6
+    cpg.call("println").postDominates.size shouldBe 7
   }
 
   "should find that method does not post dominate anything" in {

--- a/src/test/scala/io/joern/javasrc2cpg/querying/FieldAccessTests.scala
+++ b/src/test/scala/io/joern/javasrc2cpg/querying/FieldAccessTests.scala
@@ -38,6 +38,11 @@ class FieldAccessTests extends JavaSrcCodeToCpgFixture {
       |  Foo f = new Foo(5);
       |  int y = f.value;
       |}
+      |
+      |public void baz() {
+      |  Foo g = new Foo(5);
+      |  g.value = 66;
+      |}
       |}
       |""".stripMargin
 
@@ -50,10 +55,18 @@ class FieldAccessTests extends JavaSrcCodeToCpgFixture {
     fieldIdentifier.canonicalName shouldBe "MAX_VALUE"
   }
 
-  "should handle object field accesses" in {
+  "should handle object field accesses on RHS of assignments" in {
     val List(access: Call) = cpg.method(".*bar.*").call(".*fieldAccess").l
     val List(fieldIdentifier: FieldIdentifier, identifier: Identifier) = access.argument.l
     identifier.name shouldBe "f"
+    identifier.typeFullName shouldBe "Foo"
+    fieldIdentifier.canonicalName shouldBe "value"
+  }
+
+  "should handle object field accesses on LHS of assignments" in {
+    val List(access: Call) = cpg.method(".*baz.*").call(".*fieldAccess").l
+    val List(fieldIdentifier: FieldIdentifier, identifier: Identifier) = access.argument.l
+    identifier.name shouldBe "g"
     identifier.typeFullName shouldBe "Foo"
     fieldIdentifier.canonicalName shouldBe "value"
   }

--- a/src/test/scala/io/joern/javasrc2cpg/querying/LiteralTests.scala
+++ b/src/test/scala/io/joern/javasrc2cpg/querying/LiteralTests.scala
@@ -1,0 +1,67 @@
+package io.joern.javasrc2cpg.querying
+
+import com.github.javaparser.ast.expr.LiteralExpr
+import io.joern.javasrc2cpg.testfixtures.JavaSrcCodeToCpgFixture
+import io.shiftleft.codepropertygraph.generated.nodes.{Identifier, Literal}
+import io.shiftleft.semanticcpg.language._
+
+class LiteralTests extends JavaSrcCodeToCpgFixture {
+
+  override val code: String =
+    """
+      |class Test {
+      |  public void foo() {
+      |    byte a = 0b10110010;
+      |    short b = 0;
+      |    int c = 0175;
+      |    int d = 0xABCD;
+      |    long e = 9223372036854775807;
+      |    float f = 0.42f;
+      |    double g = 11d;
+      |    double h = 11.0;
+      |    double i = 1.0e2D;
+      |    char j = 'j';
+      |    char k = 062;
+      |    char l = '\n';
+      |    String m = "Hello, world!";
+      |    String n = null;
+      |    boolean o = true;
+      |    boolean p = false;
+      |  }
+      |}
+      |""".stripMargin
+
+  val expectedOutput = List(
+    ("a", "0b10110010", "int"),
+    ("b", "0", "int"),
+    ("c", "0175", "int"),
+    ("d", "0xABCD", "int"),
+    ("e", "9223372036854775807", "int"),
+    ("f", "0.42f", "float"),
+    ("g", "11d", "double"),
+    ("h", "11.0", "double"),
+    ("i", "1.0e2D", "double"),
+    ("j", "'j'", "char"),
+    ("k", "062", "int"),
+    ("l", "'\\n'", "char"),
+    ("m", "\"Hello, world!\"", "java.lang.String"),
+    ("n", "null", "null"),
+    ("o", "true", "boolean"),
+    ("p", "false", "boolean"),
+  )
+
+  "should correctly parse literals of all types" in {
+    val valueMap = cpg.assignment.map { a =>
+      val List(identifier: Identifier, value: Literal) = a.argument.l
+      identifier.name -> (identifier, value)
+    }.toMap
+
+    expectedOutput.foreach { case (identifier, value, typ) =>
+      withClue(s"$identifier should have value $value") {
+        val (actualIdentifier: Identifier, actualValue: Literal) = valueMap(identifier)
+        actualValue.code shouldBe value
+        actualIdentifier.typeFullName shouldBe typ
+      }
+    }
+  }
+}

--- a/src/test/scala/io/joern/javasrc2cpg/querying/ObjectInstantiationTests.scala
+++ b/src/test/scala/io/joern/javasrc2cpg/querying/ObjectInstantiationTests.scala
@@ -15,6 +15,10 @@ class ObjectInstantiationTests extends JavaSrcCodeToCpgFixture {
       |  public void foo() {
       |    Foo f = new Foo(12);
       |  }
+      |
+      |  public void bar() {
+      |    Bar b = new Bar(55);
+      |  }
       |}
       |""".stripMargin
 
@@ -40,6 +44,31 @@ class ObjectInstantiationTests extends JavaSrcCodeToCpgFixture {
       initializer.name shouldBe "<constructor>.Foo"
       val List(arg: Literal) = initializer.argument.l
       arg.code shouldBe "12"
+    }
+  }
+
+  "should create an AST for object instantiations where the class is known" in {
+    val assignment: Call = cpg.method(".*bar.*").assignments.l match {
+      case List(assignment: Call) => assignment
+      case res =>
+        fail(s"Error extracting assignment. Expected `List(a: Call)` but got `$res`")
+    }
+
+    val (assignee: Identifier, initializer: Call) = assignment.argument.l match {
+      case List(assignee: Identifier, initializer: Call) => (assignee, initializer)
+      case res =>
+        fail(s"Error extracting assign args. Expected `List(assignee: Identifier, initializer: Call)` but got $res")
+    }
+
+    withClue("assignee should be created correctly") {
+      assignee.name shouldBe "b"
+      assignee.typeFullName shouldBe "Bar"
+    }
+
+    withClue("initializer should be created correctly") {
+      initializer.name shouldBe "<constructor>.Bar"
+      val List(arg: Literal) = initializer.argument.l
+      arg.code shouldBe "55"
     }
   }
 }

--- a/src/test/scala/io/joern/javasrc2cpg/querying/ObjectInstantiationTests.scala
+++ b/src/test/scala/io/joern/javasrc2cpg/querying/ObjectInstantiationTests.scala
@@ -1,0 +1,45 @@
+package io.joern.javasrc2cpg.querying
+
+import io.joern.javasrc2cpg.testfixtures.JavaSrcCodeToCpgFixture
+import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier, Literal}
+import io.shiftleft.semanticcpg.language._
+
+class ObjectInstantiationTests extends JavaSrcCodeToCpgFixture {
+  override val code: String =
+    """
+      |class Bar {
+      |  public Bar(int x) {}
+      |}
+      |
+      |class Test {
+      |  public void foo() {
+      |    Foo f = new Foo(12);
+      |  }
+      |}
+      |""".stripMargin
+
+  "should create an AST for object instantiations where the class isn't known" in {
+    val assignment: Call = cpg.method(".*foo.*").assignments.l match {
+      case List(assignment: Call) => assignment
+      case res =>
+        fail(s"Error extracting assignment. Expected `List(a: Call)` but got `$res`")
+    }
+
+    val (assignee: Identifier, initializer: Call) = assignment.argument.l match {
+      case List(assignee: Identifier, initializer: Call) => (assignee, initializer)
+      case res =>
+        fail(s"Error extracting assign args. Expected `List(assignee: Identifier, initializer: Call)` but got $res")
+    }
+
+    withClue("assignee should be created correctly") {
+      assignee.name shouldBe "f"
+      assignee.typeFullName shouldBe "<empty>"
+    }
+
+    withClue("initializer should be created correctly") {
+      initializer.name shouldBe "<constructor>.Foo"
+      val List(arg: Literal) = initializer.argument.l
+      arg.code shouldBe "12"
+    }
+  }
+}


### PR DESCRIPTION
# Notes
* Add default `<empty>` values for types that cannot be resolved (e.g. due to missing source files). This is needed to prevent crashing in some cases.
* Add support for object initialization (modeled as a `<constructor>.ClassName` call).
* Add support for missing literals
# Testing
`sbt test`