### PR TITLE
Johannes/basic support 3

### DIFF
--- a/src/test/scala/io/joern/javasrc2cpg/querying/ObjectInstantiationTests.scala
+++ b/src/test/scala/io/joern/javasrc2cpg/querying/ObjectInstantiationTests.scala
@@ -37,7 +37,7 @@ class ObjectInstantiationTests extends JavaSrcCodeToCpgFixture {
 
     withClue("assignee should be created correctly") {
       assignee.name shouldBe "f"
-      assignee.typeFullName shouldBe "<empty>"
+      assignee.typeFullName shouldBe "<unresolved>.Foo"
     }
 
     withClue("initializer should be created correctly") {


### PR DESCRIPTION
# Notes
Default to `"<unresolved>.${node.typeName}"` as type name if the node type couldn't be resolved. This was specifically an issue for parameters with unresolved type names. 

I added the `<unresolved>` tag to make it explicit that the type name may not be what one expects, but this could be removed if `node.typeName` is sufficient.

# Testing
`sbt clean stage test` 