### PR TITLE
Add constructor declaration and invocation handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,22 @@ Some general development habits for the project:
   e.g. `fabs/control-structure-nodes`.
 - We currently focus around test driven development. Pay attention to the code coverage when creating new tests and 
   features. The code coverage report can be found under `./target/scala-2.13/scoverage-report`.
+
+### TODO
+- [x] Explicit constructor invocations
+- [ ] Local class declaration statements
+- [ ] Lambda expressions
+- [ ] Method Reference Expr
+- [ ] Throw statements (AST is simple, control flow to catch seems harder)
+- [ ] `this`/`super` expressions (scope for FieldAccess)
+- [ ] Type expressions (part of MethodReferenceExpr)
+- [ ] `instanceof` 
+- [ ] Pattern expr as part of `instanceof` (Java 14)
+- [ ] `switch` expressions (including `yield` statements) (Introduced Java 12/13)
+- [ ] Local record declaration statements (Java 14 Preview feature)
+
+### MAYBE TODO
+- [ ] Type arguments for generics
+- [ ] Annotations
+- [ ] Cast expressions (maybe not necessary if `javaparser` resolves types correctly)
+- [ ] Synchronized statements (if we don't just ignore those)

--- a/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -908,16 +908,6 @@ class AstCreator(filename: String, global: Global) {
     callAst(callNode, args)
   }
 
-  private def astForSuperExpr(expr: SuperExpr, order: Int): Ast = {
-    // TODO
-    Ast(NewUnknown().code(expr.toString))
-  }
-
-  private def astForThisExpr(expr: ThisExpr, order: Int): Ast = {
-    val typeName = expr.getTypeName
-    Ast(NewUnknown().code(expr.toString))
-  }
-
   private def astForExplicitConstructorInvocation(
       stmt: ExplicitConstructorInvocationStmt,
       order: Int
@@ -964,9 +954,9 @@ class AstCreator(filename: String, global: Global) {
       case x: NameExpr                => Seq(astForNameExpr(x, order))
       case x: ObjectCreationExpr      => Seq(astForObjectCreationExpr(x, order))
       case x: PatternExpr             => Seq()
-      case x: SuperExpr               => Seq(astForSuperExpr(x, order))
+      case x: SuperExpr               => Seq()
       case x: SwitchExpr              => Seq()
-      case x: ThisExpr                => Seq(astForThisExpr(x, order))
+      case x: ThisExpr                => Seq()
       case x: TypeExpr                => Seq()
       case x: UnaryExpr               => Seq(astForUnaryExpr(x, order))
       case x: VariableDeclarationExpr => astForVariableDecl(x, order)

--- a/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -388,14 +388,14 @@ class AstCreator(filename: String, global: Global) {
 
   private def astsForStatement(statement: Statement, order: Int): Seq[Ast] = {
     statement match {
-      case x: AssertStmt   => Seq(astForAssertStatement(x, order))
-      case x: BlockStmt    => Seq(astForBlockStatement(x, order))
-      case x: BreakStmt    => Seq(astForBreakStatement(x, order))
-      case x: ContinueStmt => Seq(astForContinueStatement(x, order))
-      case x: DoStmt       => Seq(astForDo(x, order))
-      case x: EmptyStmt    => Seq() // Intentionally skipping this
       case x: ExplicitConstructorInvocationStmt =>
         Seq(astForExplicitConstructorInvocation(x, order))
+      case x: AssertStmt                 => Seq(astForAssertStatement(x, order))
+      case x: BlockStmt                  => Seq(astForBlockStatement(x, order))
+      case x: BreakStmt                  => Seq(astForBreakStatement(x, order))
+      case x: ContinueStmt               => Seq(astForContinueStatement(x, order))
+      case x: DoStmt                     => Seq(astForDo(x, order))
+      case x: EmptyStmt                  => Seq() // Intentionally skipping this
       case x: ExpressionStmt             => astsForExpression(x.getExpression, order)
       case x: ForEachStmt                => Seq(astForForEach(x, order))
       case x: ForStmt                    => Seq(astForFor(x, order))

--- a/src/test/scala/io/joern/javasrc2cpg/querying/ConstructorInvocationTests.scala
+++ b/src/test/scala/io/joern/javasrc2cpg/querying/ConstructorInvocationTests.scala
@@ -1,0 +1,85 @@
+package io.joern.javasrc2cpg.querying
+
+import io.joern.javasrc2cpg.testfixtures.JavaSrcCodeToCpgFixture
+import io.shiftleft.codepropertygraph.generated.Operators
+import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier, Literal, Method}
+import io.shiftleft.semanticcpg.language._
+
+class ConstructorInvocationTests extends JavaSrcCodeToCpgFixture {
+
+  override val code: String =
+    """
+      |class Foo {
+      |  int x;
+      |  public Foo(int x) {
+      |    this.x = x;
+      |  }
+      |
+      |  public int getValue() {
+      |    return x;
+      |  }
+      |}
+      |
+      |class Bar extends Foo {
+      |  public Bar(int x) {
+      |    super(x);
+      |  }
+      |
+      |  public Bar(int x, int y) {
+      |    this(x + y);
+      |  }
+      |}
+      |""".stripMargin
+
+
+  "it should create correct method nodes for constructors" in {
+    cpg.method.name("Foo").l match {
+      case List(cons: Method) =>
+        cons.fullName shouldBe "Foo.Foo:Foo(int)"
+        cons.signature shouldBe "Foo(int)"
+        cons.code shouldBe "public Foo(int x)"
+
+      case res =>
+        fail(s"Expected single Foo constructor, but got $res")
+    }
+
+    cpg.method.name("Bar").l match {
+      case List(cons1: Method, cons2: Method) =>
+        cons1.fullName shouldBe "Bar.Bar:Bar(int)"
+        cons1.signature shouldBe "Bar(int)"
+        cons1.code shouldBe "public Bar(int x)"
+
+        cons2.fullName shouldBe "Bar.Bar:Bar(int,int)"
+        cons2.signature shouldBe "Bar(int,int)"
+        cons2.code shouldBe "public Bar(int x, int y)"
+    }
+  }
+
+  "it should create a constructor call node for the `this` statement" in {
+    cpg.call(".*Bar.*").l match {
+      case List(call: Call) =>
+        call.methodFullName shouldBe "Bar.Bar"
+        call.name shouldBe "Bar.Bar"
+        call.code shouldBe "this(x + y);"
+        call.argument.head shouldBe a[Call]
+        call.argument.head.asInstanceOf[Call].name shouldBe Operators.addition
+
+      case res =>
+        fail(s"Expected single call to Bar.Bar but got $res")
+    }
+  }
+
+  "it should create a constructor call node for the `super` statement" in {
+    cpg.call(".*Foo.*").l match {
+      case List(call: Call) =>
+        call.methodFullName shouldBe "Foo.Foo"
+        call.name shouldBe "Foo.Foo"
+        call.code shouldBe "super(x);"
+        call.argument.head shouldBe a[Identifier]
+        call.argument.head.code shouldBe "x"
+
+      case res =>
+        fail(s"Expected single call to Foo.Foo but got $res")
+    }
+  }
+}


### PR DESCRIPTION
# Notes
* JavaParser treats method and constructor declarations differently, so this adds support for constructor declarations as well.
* Add support for explicit constructor invocations (through `this` or `super`) by representing them as a call to the Constructor method.
* Add a TODO list for AST elements that are still missing. Some more TODOs may pop up to fix later passes.
# Testing
`sbt clean test`