### PR TITLE
Add dataflow tests for assignments and fix failing tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Some general development habits for the project:
 ### TODO
 - [x] Explicit constructor invocations
 - [x] Propagate context up and down while creating AST
+- [ ] `code` field for method calls (`this` for `System.out` in `System.out.println`)
 - [ ] Logging
 - [ ] Handle body of `try`/`catch` 
 - [ ] Local class declaration statements

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ organization := "io.joern"
 
 scalaVersion := "2.13.6"
 
-val cpgVersion       = "1.3.353"
+val cpgVersion       = "1.3.380"
 val scalatestVersion = "3.1.1"
 
 Test / fork := true

--- a/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
+++ b/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
@@ -2,25 +2,17 @@ package io.joern.javasrc2cpg
 
 import io.joern.javasrc2cpg.passes.AstCreationPass
 import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.Languages
 import io.shiftleft.passes.IntervalKeyPool
-import io.shiftleft.semanticcpg.passes.cfgdominator.CfgDominatorPass
-import io.shiftleft.semanticcpg.passes.codepencegraph.CdgPass
-import io.shiftleft.semanticcpg.passes.{CfgCreationPass, FileCreationPass}
-import io.shiftleft.semanticcpg.passes.containsedges.ContainsEdgePass
-import io.shiftleft.semanticcpg.passes.languagespecific.fuzzyc.MethodStubCreator
-import io.shiftleft.semanticcpg.passes.linking.calllinker.StaticCallLinker
-import io.shiftleft.semanticcpg.passes.linking.linker.Linker
 import io.shiftleft.semanticcpg.passes.metadata.MetaDataPass
-import io.shiftleft.semanticcpg.passes.methoddecorations.MethodDecoratorPass
-import io.shiftleft.semanticcpg.passes.namespacecreator.NamespaceCreator
-import io.shiftleft.semanticcpg.passes.typenodes.{TypeDeclStubCreator, TypeNodePass}
+import io.shiftleft.semanticcpg.passes.typenodes.TypeNodePass
 import io.shiftleft.x2cpg.SourceFiles
 import io.shiftleft.x2cpg.X2Cpg.newEmptyCpg
 
 import scala.jdk.CollectionConverters.EnumerationHasAsScala
 
 object JavaSrc2Cpg {
-  val language = "JAVAPARSER"
+  val language: String = Languages.JAVASRC
 
   def apply(): JavaSrc2Cpg = new JavaSrc2Cpg()
 }
@@ -50,24 +42,9 @@ class JavaSrc2Cpg {
     val astCreator           = new AstCreationPass(sourceCodePath, sourceFileNames, cpg, methodKeyPool)
     astCreator.createAndApply()
 
-    new CfgCreationPass(cpg).createAndApply()
-
-    new NamespaceCreator(cpg).createAndApply()
-    new FileCreationPass(cpg).createAndApply()
-
     new TypeNodePass(astCreator.global.usedTypes.keys().asScala.toList, cpg, Some(typesKeyPool))
       .createAndApply()
-    new TypeDeclStubCreator(cpg).createAndApply()
 
-    new ContainsEdgePass(cpg).createAndApply()
-    new Linker(cpg).createAndApply()
-
-    new MethodStubCreator(cpg).createAndApply()
-    new MethodDecoratorPass(cpg).createAndApply()
-    new StaticCallLinker(cpg).createAndApply()
-
-    new CfgDominatorPass(cpg).createAndApply()
-    new CdgPass(cpg).createAndApply()
     cpg
   }
 

--- a/src/test/resources/default.semantics
+++ b/src/test/resources/default.semantics
@@ -1,0 +1,39 @@
+# "<operator>.sizeOf" reduces the FPs
+# 1->-1 first parameter mapped to return value (-1)
+"<operator>.addition" 1->-1 2->-1
+"<operator>.addressOf" 1->-1
+"<operator>.assignment" 2->1
+"<operator>.assignmentAnd" 2->1 1->1
+"<operator>.assignmentArithmeticShiftRight" 2->1 1->1
+"<operator>.assignmentDivision" 2->1 1->1
+"<operator>.assignmentExponentiation" 2->1 1->1
+"<operator>.assignmentLogicalShiftRight" 2->1 1->1
+"<operator>.assignmentMinus" 2->1 1->1
+"<operator>.assignmentModulo" 2->1 1->1
+"<operator>.assignmentMultiplication" 2->1 1->1
+"<operator>.assignmentOr" 2->1 1->1
+"<operator>.assignmentPlus" 2->1 1->1
+"<operator>.assignmentShiftLeft" 2->1 1->1
+"<operator>.assignmentXor" 2->1 1->1
+"<operator>.computedMemberAccess" 1->-1
+"<operator>.conditional" 2->-1 3->-1
+"<operator>.fieldAccess" 1->-1
+"<operator>.getElementPtr" 1->-1
+"<operator>.incBy 2->1 3->1 4->1"
+"<operator>.indexAccess" 1->-1
+"<operator>.indirectComputedMemberAccess" 1->-1
+"<operator>.indirectFieldAccess" 1->-1
+"<operator>.indirectIndexAccess" 1->-1
+"<operator>.indirectMemberAccess" 1->-1
+"<operator>.indirection" 1->-1
+"<operator>.memberAccess" 1->-1
+"<operator>.pointerShift" 1->-1
+"<operator>.postDecrement" 1->1
+"<operator>.postIncrement" 1->1
+"<operator>.preDecrement" 1->1
+"<operator>.preIncrement" 1->1
+"<operator>.sizeOf"
+"free" 1->1
+"scanf" 2->2
+"strcmp" 1->-1 2->-1
+"woo" 1->-1

--- a/src/test/scala/io/joern/javasrc2cpg/JavaSrc2CpgTestContext.scala
+++ b/src/test/scala/io/joern/javasrc2cpg/JavaSrc2CpgTestContext.scala
@@ -1,6 +1,7 @@
 package io.joern.javasrc2cpg
 
 import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
 import io.shiftleft.semanticcpg.layers.{LayerCreatorContext, Scpg}
 
 import java.io.{File, PrintWriter}
@@ -10,12 +11,16 @@ class JavaSrc2CpgTestContext {
   private var code: String = ""
   private var buildResult = Option.empty[Cpg]
 
-  def buildCpg: Cpg = {
+  def buildCpg(runDataflow: Boolean): Cpg = {
     if (buildResult.isEmpty) {
       val javaSrc2Cpg = JavaSrc2Cpg()
       val cpg = javaSrc2Cpg.createCpg(writeCodeToFile(code).getAbsolutePath)
       val context = new LayerCreatorContext(cpg)
       new Scpg().run(context)
+      if (runDataflow) {
+        val options = new OssDataFlowOptions()
+        new OssDataFlow(options).run(context)
+      }
       buildResult = Some(cpg)
     }
     buildResult.get
@@ -40,6 +45,12 @@ object JavaSrc2CpgTestContext {
   def buildCpg(code: String): Cpg = {
     new JavaSrc2CpgTestContext()
       .withSource(code)
-      .buildCpg
+      .buildCpg(runDataflow = false)
+  }
+
+  def buildCpgWithDataflow(code: String): Cpg = {
+    new JavaSrc2CpgTestContext()
+      .withSource(code)
+      .buildCpg(runDataflow = true)
   }
 }

--- a/src/test/scala/io/joern/javasrc2cpg/JavaSrc2CpgTestContext.scala
+++ b/src/test/scala/io/joern/javasrc2cpg/JavaSrc2CpgTestContext.scala
@@ -1,8 +1,11 @@
 package io.joern.javasrc2cpg
 
 import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import io.shiftleft.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
 import io.shiftleft.semanticcpg.layers.{LayerCreatorContext, Scpg}
+
+import scala.jdk.CollectionConverters._
 
 import java.io.{File, PrintWriter}
 import java.nio.file.Files

--- a/src/test/scala/io/joern/javasrc2cpg/querying/MetaDataTests.scala
+++ b/src/test/scala/io/joern/javasrc2cpg/querying/MetaDataTests.scala
@@ -1,6 +1,7 @@
 package io.joern.javasrc2cpg.querying
 
 import io.joern.javasrc2cpg.testfixtures.JavaSrcCodeToCpgFixture
+import io.shiftleft.codepropertygraph.generated.Languages
 import io.shiftleft.semanticcpg.language._
 
 class MetaDataTests extends JavaSrcCodeToCpgFixture {
@@ -12,7 +13,7 @@ class MetaDataTests extends JavaSrcCodeToCpgFixture {
 
   "should contain exactly one node with all mandatory fields set" in {
     val List(x) = cpg.metaData.l
-    x.language shouldBe "JAVAPARSER"
+    x.language shouldBe Languages.JAVASRC
     x.version shouldBe "0.1"
     x.overlays shouldBe List("semanticcpg")
   }

--- a/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/OperatorTests.scala
+++ b/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/OperatorTests.scala
@@ -1,0 +1,103 @@
+package io.joern.javasrc2cpg.querying.dataflow
+
+import io.joern.javasrc2cpg.testfixtures.JavaDataflowFixture
+import io.shiftleft.dataflowengineoss.language._
+
+class OperatorTests extends JavaDataflowFixture {
+  behavior of "Dataflow through operators"
+  override val code: String = """
+    |public class Foo {
+    |  public void test1() {
+    |    String s = "MALICIOUS";
+    |    System.out.println(s);
+    |  }
+    |
+    |  public void test2() {
+    |    int x = 42;
+    |    int y = x;
+    |    int z = y;
+    |    System.out.println(z);
+    |  }
+    |
+    |  public void test3(String suffix) {
+    |    String s = "MALICIOUS";
+    |    String t = s + safe;
+    |    System.out.println(t);
+    |  }
+    |
+    |  public void test4(boolean shouldToggle) {
+    |    String bad = "MALICIOUS";
+    |    String s = shouldToggle ? "SAFE" : bad;
+    |
+    |    System.out.println(s);
+    |  }
+    |
+    |  public void test5() {
+    |    int bad = 42;
+    |    int good = 0;
+    |    int veryGood = 11;
+    |
+    |    int maybeBad = good + (veryGood + bad);
+    |    System.out.println(maybeBad);
+    |  }
+    |
+    |  public void test6() {
+    |    String s = "MALICIOUS";
+    |    s = "SAFE";
+    |    System.out.println(s);
+    |  }
+    |
+    |  public void test7() {
+    |    String s = "SAFE";
+    |    s += "MALICIOUS";
+    |    System.out.println(s);
+    |  }
+    |
+    |  public void test8() {
+    |     String s = "MALICIOUS";
+    |     s += "SAFE";
+    |     System.out.println(s);
+    |  }
+    |}
+    |""".stripMargin
+
+  it should "track dataflow through direct assignment" in {
+    val (source, sink) = getConstSourceSink("test1" )
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "track dataflow through multiple assignments" in {
+    val (source, sink) = getConstSourceSink("test2", sourceCode = "42")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "track dataflow through a binary operation" in {
+    val (source, sink) = getConstSourceSink("test3")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "track dataflow through a conditional expression" in {
+    val (source, sink) = getConstSourceSink("test4")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "track dataflow through nested operations" in {
+    val (source, sink) = getConstSourceSink("test5", sourceCode = "42")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "not track dataflow through a reassignment" in {
+    val (source, sink) = getConstSourceSink("test6")
+    sink.reachableBy(source).size shouldBe 0
+  }
+
+  it should "track dataflow through += where malicious input is added" in {
+    val (source, sink) = getConstSourceSink("test7")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "track dataflow through += where safe input is added" in {
+    val (source, sink) = getConstSourceSink("test8")
+    sink.reachableBy(source).size shouldBe 1
+  }
+}

--- a/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaDataflowFixture.scala
+++ b/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaDataflowFixture.scala
@@ -2,7 +2,7 @@ package io.joern.javasrc2cpg.testfixtures
 
 import io.joern.javasrc2cpg.JavaSrc2CpgTestContext
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.nodes.{AstNode, Expression, Literal, Method}
+import io.shiftleft.codepropertygraph.generated.nodes.{Expression, Literal}
 import io.shiftleft.dataflowengineoss.queryengine.{EngineConfig, EngineContext}
 import io.shiftleft.dataflowengineoss.semanticsloader.{Parser, Semantics}
 import io.shiftleft.semanticcpg.language._
@@ -16,7 +16,7 @@ class JavaDataflowFixture extends AnyFlatSpec with Matchers {
   val semanticsFile: String = ProjectRoot.relativise("src/test/resources/default.semantics")
   lazy val defaultSemantics: Semantics = Semantics.fromList(new Parser().parseFile(semanticsFile))
   implicit val resolver: ICallResolver = NoResolve
-  implicit val engineContext: EngineContext = EngineContext(defaultSemantics, EngineConfig(maxCallDepth = 4))
+  implicit lazy val engineContext: EngineContext = EngineContext(defaultSemantics, EngineConfig(maxCallDepth = 4))
 
   val code: String = ""
   lazy val cpg: Cpg = JavaSrc2CpgTestContext.buildCpgWithDataflow(code)

--- a/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaDataflowFixture.scala
+++ b/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaDataflowFixture.scala
@@ -1,0 +1,53 @@
+package io.joern.javasrc2cpg.testfixtures
+
+import io.joern.javasrc2cpg.JavaSrc2CpgTestContext
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes.{AstNode, Expression, Literal, Method}
+import io.shiftleft.dataflowengineoss.queryengine.{EngineConfig, EngineContext}
+import io.shiftleft.dataflowengineoss.semanticsloader.{Parser, Semantics}
+import io.shiftleft.semanticcpg.language._
+import io.shiftleft.utils.ProjectRoot
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import overflowdb.traversal.Traversal
+
+class JavaDataflowFixture extends AnyFlatSpec with Matchers {
+
+  val semanticsFile: String = ProjectRoot.relativise("src/test/resources/default.semantics")
+  lazy val defaultSemantics: Semantics = Semantics.fromList(new Parser().parseFile(semanticsFile))
+  implicit val resolver: ICallResolver = NoResolve
+  implicit val engineContext: EngineContext = EngineContext(defaultSemantics, EngineConfig(maxCallDepth = 4))
+
+  val code: String = ""
+  lazy val cpg: Cpg = JavaSrc2CpgTestContext.buildCpgWithDataflow(code)
+
+  def getConstSourceSink(
+      methodName: String,
+      sourceCode: String = "\"MALICIOUS\"",
+      sinkPattern: String = ".*println.*"
+  ): (Traversal[Literal], Traversal[Expression]) = {
+    getMultiFnSourceSink(methodName, methodName, sourceCode, sinkPattern)
+  }
+
+  def getMultiFnSourceSink(
+      sourceMethodName: String,
+      sinkMethodName: String,
+      sourceCode: String = "\"MALICIOUS\"",
+      sinkPattern: String = ".*println.*"
+  ): (Traversal[Literal], Traversal[Expression]) = {
+    val sourceMethod = cpg.method(s".*$sourceMethodName.*").head
+    val sinkMethod = cpg.method(s".*$sinkMethodName.*").head
+    def source = sourceMethod.literal.code(sourceCode)
+    def sink = sinkMethod.call.name(sinkPattern).argument.ast.isIdentifier
+
+    // If either of these fail, then the testcase was written incorrectly or the AST was created incorrectly.
+    if (source.size <= 0) {
+      fail(s"Could not find source $sourceCode in method $sourceMethodName")
+    }
+    if (sink.size <= 0) {
+      fail(s"Could not find sink $sinkPattern for method $sinkMethodName")
+    }
+
+    (source, sink)
+  }
+}


### PR DESCRIPTION
# Notes
* CPG version bump (with corresponding fixes in AstCreator)
* Remove cpg passes that were added to `codepropertygraph` in https://github.com/ShiftLeftSecurity/codepropertygraph/pull/1462
* Add dataflow tests for assignments
* Add `dispatchType(DispatchTypes.STATIC_DISPATCH)` to assignment calls
* Add operator type to assignment calls (e.g. `Operators.assignmentPlus`)