### PR TITLE
Fix dataflow through `switch` statements (and add tests)

### DIFF
--- a/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/SwitchTests.scala
+++ b/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/SwitchTests.scala
@@ -1,0 +1,53 @@
+package io.joern.javasrc2cpg.querying.dataflow
+
+import io.joern.javasrc2cpg.testfixtures.JavaDataflowFixture
+import io.shiftleft.dataflowengineoss.language._
+
+class SwitchTests extends JavaDataflowFixture {
+
+  behavior of "Dataflow through `SWITCH`"
+
+  override val code: String =
+    """
+      |public class Foo {
+      |    public void test1(int input) {
+      |        String s;
+      |
+      |        switch (input) {
+      |            case 0:
+      |            case 1:
+      |                s = "SAFE";
+      |                break;
+      |            case 2:
+      |                s = "MALICIOUS";
+      |                break;
+      |            default:
+      |                s = "SAFE";
+      |        }
+      |        System.out.println(s);
+      |    }
+      |
+      |    public void test2(int input) {
+      |        String s = "MALICIOUS";
+      |
+      |        switch(input) {
+      |            case 0:
+      |                System.out.println(s);
+      |                break;
+      |            default:
+      |                System.out.println("SAFE");
+      |        }
+      |    }
+      |}
+      |""".stripMargin
+
+  it should "find a path if the source is in a switch" in {
+    val (source, sink) = getConstSourceSink("test1")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "find a path if the sink is in a switch" in {
+    val (source, sink) = getConstSourceSink("test2")
+    sink.reachableBy(source).size shouldBe 1
+  }
+}

--- a/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/SwitchTests.scala
+++ b/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/SwitchTests.scala
@@ -48,6 +48,6 @@ class SwitchTests extends JavaDataflowFixture {
 
   it should "find a path if the sink is in a switch" in {
     val (source, sink) = getConstSourceSink("test2")
-    sink.reachableBy(source).size shouldBe 1
+    sink.reachableBy(source).size shouldBe 2
   }
 }


### PR DESCRIPTION
# Notes
* Make switch AST more consistent with that of `c2cpg`. The switch node now has 2 children: the selector AST and a block containing the switch body.
* Fix orders for nodes in the switch body.
* Add JumpTargets for `default` cases.
* Change non-default JumpTarget name to `case` to fix CFG generation.