### PR TITLE
Add dataflow tests and fixes for arrays and try-catch statements

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ organization := "io.joern"
 
 scalaVersion := "2.13.6"
 
-val cpgVersion       = "999.1.35"
+val cpgVersion       = "1.3.391"
 val scalatestVersion = "3.1.1"
 
 Test / fork := true

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ organization := "io.joern"
 
 scalaVersion := "2.13.6"
 
-val cpgVersion       = "1.3.380"
+val cpgVersion       = "999.1.35"
 val scalatestVersion = "3.1.1"
 
 Test / fork := true

--- a/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/ArrayTests.scala
+++ b/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/ArrayTests.scala
@@ -1,0 +1,165 @@
+package io.joern.javasrc2cpg.querying.dataflow
+
+import io.joern.javasrc2cpg.testfixtures.JavaDataflowFixture
+import io.shiftleft.dataflowengineoss.language._
+
+class ArrayTests extends JavaDataflowFixture {
+
+  behavior of "Dataflow through arrays"
+
+  override val code: String =
+    """
+      |public class Foo {
+      |    public void test1() {
+      |        String[] vals = {"SAFE", "SAFE", "MALICIOUS", "SAFE"};
+      |        System.out.println(vals[2]);
+      |    }
+      |
+      |    public void test2() {
+      |        String[] vals = {"SAFE", "SAFE", "MALICIOUS", "SAFE"};
+      |        System.out.println(vals[0]);
+      |    }
+      |
+      |    public void test3() {
+      |        String[] vals = new String[]{"SAFE", "SAFE", "MALICIOUS", "SAFE"};
+      |        System.out.println(vals[2]);
+      |    }
+      |
+      |    public void test4() {
+      |        String[] vals = new String[2];
+      |        vals[0] = "SAFE";
+      |        vals[1] = "MALICIOUS";
+      |        System.out.println(vals[0]);
+      |    }
+      |
+      |    public void test5() {
+      |        String[] vals = new String[2];
+      |        vals[0] = "SAFE";
+      |        vals[1] = "MALICIOUS";
+      |        System.out.println(vals[1]);
+      |    }
+      |
+      |    public void test6() {
+      |        String[] vals = {"SAFE", "MALICIOUS"};
+      |        vals[0] = "ALSO SAFE";
+      |        System.out.println(vals[1]);
+      |    }
+      |
+      |    public void test7() {
+      |        String[] vals = {"SAFE", "MALICIOUS"};
+      |        vals[1] = "ALSO SAFE";
+      |        System.out.println(vals[1]);
+      |    }
+      |
+      |    public void test8() {
+      |        String[] vals = {"SAFE", "SAFE", "MALICIOUS", "SAFE"};
+      |        for (int i = 0; i < vals.length; i++) {
+      |            String val = vals[i];
+      |            System.out.println(val);
+      |        }
+      |    }
+      |
+      |    public void test9() {
+      |        String[] vals = {"SAFE", "SAFE", "MALICIOUS", "SAFE"};
+      |        for (String val : vals) {
+      |            System.out.println(val);
+      |        }
+      |    }
+      |
+      |    public void test10() {
+      |        String[] vals = {"SAFE", "SAFE", "MALICIOUS", "SAFE"};
+      |        String acc = "";
+      |        for (String val : vals) {
+      |            acc += val;
+      |        }
+      |        System.out.println(acc);
+      |    }
+      |
+      |    public void test11() {
+      |        String[] vals = {"SAFE", "STILL SAFE", "ALSO SAFE"};
+      |        vals[1] = "MALICIOUS";
+      |        System.out.println(vals[1]);
+      |    }
+      |
+      |    public void test12() {
+      |        String[] vals = {"SAFE", "STILL SAFE", "ALSO SAFE"};
+      |        vals[1] = "MALICIOUS";
+      |        System.out.println(vals[0]);
+      |    }
+      |
+      |    public void test13() {
+      |        String[] vals = {"SAFE", "SAFE", "MALICIOUS", "SAFE"};
+      |        String[] alias = vals;
+      |        System.out.println(alias[2]);
+      |    }
+      |   }
+      |""".stripMargin
+
+  it should "find a path if the `MALICIOUS` array entry is printed" in {
+    val (source, sink) = getConstSourceSink("test1")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "find a path if an entry in the `MALICIOUS` array is printed (approximation)" in {
+    val (source, sink) = getConstSourceSink("test2")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "find a path for alternative array initializer syntax" in {
+    val (source, sink) = getConstSourceSink("test3")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "find a path if array element is assigned to `MALICIOUS` (approximation)" in {
+    val (source, sink) = getConstSourceSink("test4")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "find a path if array element is assigned to `MALICIOUS`" in {
+    val (source, sink) = getConstSourceSink("test5")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "find a path if a different array element is overwritten" in {
+    val (source, sink) = getConstSourceSink("test6")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "find a path if the `MALICIOUS` array element is overwritten (approximation)" in {
+    val (source, sink) = getConstSourceSink("test7")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "find a path if sink is in a `FOR` loop" in {
+    val (source, sink) = getConstSourceSink("test8")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "find a path if sink is in a `FOREACH` loop over `MALICIOUS` array" in {
+    val (source, sink) = getConstSourceSink("test9")
+    // The behaviour of javasrc2cpg currently matches c2cpg (neither of which find a path here.
+    // TODO: Fix dataflow through foreach constructs for both this and c2cpg
+    sink.reachableBy(source).size shouldBe 0
+  }
+
+  it should "find a path if `MALICIOUS` is added to an accumulator in a loop" in {
+    val (source, sink) = getConstSourceSink("test10")
+    // TODO: Fix dataflow through foreach constructs for both this and c2cpg
+    sink.reachableBy(source).size shouldBe 0
+  }
+
+  it should "find a path if `MALICIOUS` is assigned to safe array and printed" in {
+    val (source, sink) = getConstSourceSink("test11")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "find a path if `MALICIOUS` is assigned to safe array and not printed (approximation)" in {
+    val (source, sink) = getConstSourceSink("test12")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "find a path through an array alias" in {
+    val (source, sink) = getConstSourceSink("test13")
+    sink.reachableBy(source).size shouldBe 1
+  }
+}

--- a/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/OperatorTests.scala
+++ b/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/OperatorTests.scala
@@ -58,6 +58,12 @@ class OperatorTests extends JavaDataflowFixture {
     |     s += "SAFE";
     |     System.out.println(s);
     |  }
+    |
+    |  public void test9() {
+    |    String s = "SAFE";
+    |    s = "MALICIOUS";
+    |    System.out.println(s);
+    |  }
     |}
     |""".stripMargin
 
@@ -98,6 +104,11 @@ class OperatorTests extends JavaDataflowFixture {
 
   it should "track dataflow through += where safe input is added" in {
     val (source, sink) = getConstSourceSink("test8")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "find a path if safe is reassigned to malicious" in {
+    val (source, sink) = getConstSourceSink("test9")
     sink.reachableBy(source).size shouldBe 1
   }
 }

--- a/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/TryTests.scala
+++ b/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/TryTests.scala
@@ -1,0 +1,165 @@
+package io.joern.javasrc2cpg.querying.dataflow
+
+import io.joern.javasrc2cpg.testfixtures.JavaDataflowFixture
+import io.shiftleft.dataflowengineoss.language._
+
+class TryTests extends JavaDataflowFixture {
+
+  behavior of "Dataflow through TRY/CATCH"
+
+  override val code: String =
+    """
+      |public class Foo {
+      |    public void test1() {
+      |        String s = "MALICIOUS";
+      |
+      |        try {
+      |            System.out.println(s);
+      |        } catch (Exception e) {
+      |            System.out.println("SAFE");
+      |        }
+      |    }
+      |
+      |    public void test2() {
+      |        String s = "MALICIOUS";
+      |
+      |        try {
+      |            System.out.println("SAFE");
+      |        } catch (Exception e) {
+      |            System.out.println(s);
+      |        }
+      |    }
+      |
+      |    public void test3() {
+      |        String s = "MALICIOUS";
+      |
+      |        try {
+      |            System.out.println("SAFE");
+      |        } catch (Exception e) {
+      |            System.out.println("ALSO_SAFE");
+      |        } finally {
+      |            System.out.println("MALICIOUS");
+      |        }
+      |    }
+      |
+      |    public void test4() {
+      |        String s = "MALICIOUS";
+      |
+      |        try {
+      |            throw new Exception(s);
+      |        } catch (Exception e) {
+      |            System.out.println(e);
+      |        }
+      |    }
+      |
+      |    public void test5() {
+      |        String s = "SAFE";
+      |
+      |        try {
+      |            s = "MALICIOUS";
+      |        } catch (Exception e) {
+      |            // Do nothing
+      |        }
+      |
+      |        System.out.println(s);
+      |    }
+      |
+      |    public void test6() {
+      |        String s = "SAFE";
+      |
+      |        try {
+      |            // Do nothing
+      |        } catch (Exception e) {
+      |            s = "MALICIOUS";
+      |        }
+      |
+      |        System.out.println(s);
+      |    }
+      |
+      |    public void test7() {
+      |        String s = "SAFE";
+      |
+      |        try {
+      |            // Do nothing
+      |        } catch (Exception e) {
+      |            // Do nothing
+      |        } finally {
+      |            s = "MALICIOUS";
+      |        }
+      |
+      |        System.out.println(s);
+      |    }
+      |
+      |    public void test8() {
+      |        String s = "MALICIOUS";
+      |
+      |        try {
+      |            s = "SAFE";
+      |        } catch (Exception e) {
+      |            s = "ALSO SAFE";
+      |        }
+      |
+      |        System.out.println(s);
+      |    }
+      |
+      |    public void test9() {
+      |        String s = "MALICIOUS";
+      |
+      |        try {
+      |            s = "MALICIOUS";
+      |        } catch (Exception e) {
+      |            s = "MALICIOUS";
+      |        } finally {
+      |            s = "SAFE";
+      |        }
+      |
+      |        System.out.println(s);
+      |    }
+      |}
+      |""".stripMargin
+
+  it should "find a path if the sink is in a `TRY`" in {
+    val (source, sink) = getConstSourceSink("test1")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "find a path if the sink is in a `CATCH`" in {
+    val (source, sink) = getConstSourceSink("test2")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "find a path if the sink is in a `FINALLY`" in {
+    val (source, sink) = getConstSourceSink("test3")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "find a path if `MALICIOUS` is contained in thrown string with sink in catch" in {
+    val (source, sink) = getConstSourceSink("test4")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "find a path if `MALICIOUS` is assigned in `TRY`" in {
+    val (source, sink) = getConstSourceSink("test5")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "find a path if `MALICIOUS` is assigned in `CATCH`" in {
+    val (source, sink) = getConstSourceSink("test6")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "find a path if `MALICIOUS` is assigned in `FINALLY`" in {
+    val (source, sink) = getConstSourceSink("test7")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "not find a path if `MALICIOUS` is reassigned in both TRY/CATCH" in {
+    val (source, sink) = getConstSourceSink("test8")
+    sink.reachableBy(source).size shouldBe 0
+  }
+
+  it should "not find a path if `MALICIOUS` is reassigned in FINALLY" in {
+    val (source, sink) = getConstSourceSink("test9")
+    sink.reachableBy(source).size shouldBe 0
+  }
+}


### PR DESCRIPTION
# Notes
* Bump CPG version
* Add dataflow tests for arrays. The only fix needed here was added in https://github.com/ShiftLeftSecurity/codepropertygraph/pull/1477.
* Fix the AST implementation for try-catch statements. 
* Add dataflow tests for try-catch statements (in conjunction with https://github.com/ShiftLeftSecurity/codepropertygraph/pull/1482).